### PR TITLE
Use CONTINUE_BUTTON_TEXT in forms

### DIFF
--- a/consent.js
+++ b/consent.js
@@ -165,6 +165,7 @@ let consent_block = {
     data : {uil_save : true},
     preamble: CONSENT_HTML_STYLE_UU + CONSENT_HTML,
     required_message: IF_REQUIRED_FEEDBACK_MESSAGE,
+    button_label: CONTINUE_BUTTON_TEXT,
     questions: [
         {
             prompt: "", 

--- a/survey.js
+++ b/survey.js
@@ -39,6 +39,7 @@ const survey_1 = {
     },
     preamble :  AGE_PROMPT,
     html :      AGE_HTML,
+    button_label : CONTINUE_BUTTON_TEXT,
 
     on_finish : function(data) {
         data.rt = Math.round(data.rt);
@@ -72,6 +73,7 @@ const HAND_OPTIONS = ["Left", "Right"];
 
 const survey_2 = {
     type: 'survey-multi-choice',
+    button_label: CONTINUE_BUTTON_TEXT,
     data: {
         uil_save : true,
         survey_data_flag : true


### PR DESCRIPTION
The continue buttons of some of the forms are getting there default value, which is the English "continue". Generally,  we use the CONTINUE_BUTTON_TEXT for all continue buttons.
This pull request make the survey van informed consent forms use the global CONTINUE_BUTTON_TEXT, so that one has to apply this change once for a boilerplate.