### PR TITLE
saving data when the experiment ends, without a timeout

### DIFF
--- a/instructions.js
+++ b/instructions.js
@@ -54,7 +54,7 @@ const PRE_TEST_INSTRUCTION =
     "</p>";
 
 const POST_TEST_INSTRUCTION =
-    "<h1>End of the experiment part.</h1>"                              +
+    "<h1>End of the experiment.</h1>"                                   +
     "<h2>Many thanks for participating</h2>";
 
 const FINISHED_NO_CONSENT = 

--- a/main.js
+++ b/main.js
@@ -2,14 +2,6 @@ let jsPsych = initJsPsych({
     exclusions: {
         min_width : MIN_WIDTH,
         min_height : MIN_HEIGHT
-    },
-    on_finish: function() {
-        if (consent_given) {
-            uil.saveData();
-        }
-        else {
-            document.body.innerHTML = FINISHED_NO_CONSENT;
-        }
     }
 });
 
@@ -111,9 +103,13 @@ let end_experiment = {
     type : jsPsychHtmlKeyboardResponse,
     stimulus : POST_TEST_INSTRUCTION,
     choices : [],
-    trial_duration : FINISH_TEXT_DUR,
-    on_finish: function (data) {
-        data.rt = Math.round(data.rt);
+    on_load: function() {
+        if (consent_given) {
+            uil.saveData();
+        }
+        else {
+            document.body.innerHTML = FINISHED_NO_CONSENT;
+        }
     }
 }
 


### PR DESCRIPTION
There's one disadvantage to this change: when running the experiment offline, you don't get to see the final screen, as it will be replaced by the JSON data immediately.