### PR TITLE
Past the list name to the kickOffExperiment func

### DIFF
--- a/main.js
+++ b/main.js
@@ -220,7 +220,7 @@ function main() {
     // groups there.
     // uil.session.start(ACCESS_KEY, (group_name) => {
     //     let stimuli = findList(group_name);
-    //     kickOffExperiment(getTimeline(stimuli.table));
+    //     kickOffExperiment(getTimeline(stimuli.table), stimuli.list_name);
     // });
 }
 

--- a/stimuli.js
+++ b/stimuli.js
@@ -11,7 +11,8 @@ const PRAC      = "PRAC";
 // 34:8, 991-1015, DOI: 10.1080/23273798.2019.1602733.
 // Questions made up by Iris Mulders.
 
-// Lists 
+// Lists if you use server side balancing make sure they match the lists
+// in the target groups, this is case sensitive.
 const LISTS = [
     "list1",
     "list2"


### PR DESCRIPTION
In the section that was commented out, the list name wasn't passed allong, adding an undefined to a js object which makes it ignored in the output of the experiment.

fixes #37