### PR TITLE
Feature/stim grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ upload-experiment.sh
 
 # Ignore the key used for testing purposes
 key.txt
+
+# node
+node_modules
+
+#vs code
+.vscode

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ as that might be more readable than e.g.
 {{double }}{{curly }}{{braces}}
 ```
 
-In this example the spaces are embedded inside the groups, both method are
+In this example the spaces are embedded inside the groups, both methods are
 fine, but the author finds the first method better readable. If you put
 none white space characters outside of a group it will be considered a syntax error.
 

--- a/README.md
+++ b/README.md
@@ -45,58 +45,66 @@ conditions, you'd need to create four lists.
 
 ### Presenting multiple words as one group
 
-By defaut, the boilerplate experiment treats every word in the stimuli as a
-group of its own containing one word. Note, in some papers, the terminology for
-a group is a segment. Sometimes it is handy to group multiple words together,
-to shorten the time it takes to complete the experiment for example. This is
-possible, but must be enabled. The file `globals.js` contains another variable:
+Previously, when the spr was presenting multiple words as one group/simultaneous, you
+needed to separate them by inserting e.g. a `/`, as of now, you have to
+specifically create groups yourself and grouping of words is always on. On
+the. There are two kinds of groups `{{A group of words that is not recorded}}`
+`{{#A group of words that is NOT recorded.}}`. Recorded means that the
+RT of this group is logged. Of course it is fine to have just one `{{word}}`
+in a {{#group}}. the curly braces and # are stripped from the rendered
+output. You should not put word letters etc outside of a group.
 
-```javascript
-const GROUPING_STRING = null;
+All the words of your spr need to be enclosed in **{{**double curly braces**}}**
+so the phrase "double curly braces" is presented together. If you want the to
+be presented individually, you'll need to make three groups such as
+
+```
+{{double}} {{curly}} {{braces}}
 ```
 
-To enable grouping you must define a useful delimiter between groups.
-A little bit further in the file there's a commented version of this:
+#### White space issues
 
-```javascript
-const GROUPING_STRING = "/";
+In the example with three groups above, the " " are put outside of the group
+as that might be more readable than e.g.
+
+```
+{{double }}{{curly }}{{braces}}
 ```
 
-So in order to enable grouping, comment the first version and uncomment
-the latter. In theory you can fill out any string instead of the `"/"`
-(useful in case you need to use / in a stimulus).
-Notice the string is turned into a regular expression in order to split
-the stimulus into parts and to remove the `/` in the case described here.
+In this example the spaces are embedded inside the groups, both method are
+fine, but the author finds the first method better readable. If you put
+none white space characters outside of a group it will be considered a syntax error.
 
-```javascript
-re = RegExp(GROUPING_STRING,'gu');
+#### Presenting **bold** and *italic* words or ***both***
+
+Like HTML you can render words in bold or italic like this:
+
+```
+{{a word in <b>bold</b> or some words <i>in italic</i>}}
 ```
 
-So make sure if you are going to be creative, that the expression is valid.
+or even both.
 
-### Warning the grouping string is going to be removed as it shouldn't be displayed
-
-In the stimulus file you should take care that the grouping string is removed
-from the stimulus. So you should take in mind how the stimulus would appear
-after the grouping string is removed.
-
-#### Example
-
-```javascript
-{
-    stimulus : "This is/my fantasic stimlus./Don't you think!"
-}
+```
+{{<b><i>Bold and italic</i></b>}}
 ```
 
-The "/" will be removed, essentially gluing "is" and "my" together, just like
-"stimulus." and "Word".
+However, the syntax for this is more strict than HTML, forgetting to close a bold
+or italic tag will result in an error. The bold or you'll have to close the
+innermost group first and then the outermost group. So the following are errors:
 
-#### Example improved
+1.
 
-```javascript
-{
-    stimulus : "This is/ my fantasic stimlus./ Don't you think"
-}
+        {{<b><i>Oops close i first</b></i>}}
+
+2.
+
+        {{<b>Oops forgot to close b}}
+
+If you want then to be partially overlapping you should open a new group
+
+```
+{{<b>Bold <i> and italic</i></b> <i>, only italic</i>
 ```
 
 ## Output

--- a/build.bash
+++ b/build.bash
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-npx nearleyc -o ./plugins/grammar.js ./plugins/grammar.ne
+npx nearleyc -o ./plugins/grammar.js ./plugins/grammar.ne -e spr_grammar

--- a/build.bash
+++ b/build.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+npx nearleyc -o ./plugins/grammar.js ./plugins/grammar.ne

--- a/build.bash
+++ b/build.bash
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+# "Compile" grammar.js, from grammar.ne
 npx nearleyc -o ./plugins/grammar.js ./plugins/grammar.ne -e spr_grammar
+
+# package it using esbuild
+node ./build.mjs

--- a/build.mjs
+++ b/build.mjs
@@ -1,0 +1,13 @@
+import * as esbuild from 'esbuild'
+
+await esbuild.build({
+    entryPoints: [
+        './plugins/jspsych-spr-moving-window.js',
+    ],
+    bundle:true,
+    outdir: 'dist',
+    minify: false,
+    sourcemap: true,
+    format: "esm"
+})
+

--- a/globals.js
+++ b/globals.js
@@ -42,12 +42,3 @@ const FIX_CHOICES = [' '];
 // is on screen.
 const FINISH_TEXT_DUR = 3000;
 
-// If no grouping character is selected or if it is null as in this example
-// every word is a group of its own: sentences are split on whitespace.
-// each word will be a one word group
-const GROUPING_STRING = null;
-// Or create word groups based on a splitting string
-// Create groups using a "/". Note that every occurrence
-// of a "/" will lead to presentation as a word group and the a "/" itself
-// will not be displayed in the stimulus
-//const GROUPING_STRING = "/";

--- a/index.html
+++ b/index.html
@@ -29,6 +29,8 @@
         <!--maybe one day this plugin will be put in the mainline jsPsych
              repository.-->
         <script src="plugins/jspsych-spr-moving-window.js"></script>
+        <script type="module" src="plugins/grammar.js"></script>
+        <script type="module" src="plugins/parts.js"></script>
 
         <script src="main.js"></script>
         <style>

--- a/index.html
+++ b/index.html
@@ -28,11 +28,10 @@
 
         <!--maybe one day this plugin will be put in the mainline jsPsych
              repository.-->
-        <script src="plugins/jspsych-spr-moving-window.js"></script>
-        <script type="module" src="plugins/grammar.js"></script>
-        <script type="module" src="plugins/parts.js"></script>
+        <script type="module" src="dist/grammar.js"></script>
+        <script type="module" src="dist/parts.js"></script>
 
-        <script src="main.js"></script>
+        <script type="module" src="main.js"></script>
         <style>
             .jspsych-survey-multi-choice-text {
                 text-align: left !important;
@@ -42,8 +41,4 @@
 
     </head>
     <body></body>
-    <script>
-        // see main.js for the main function and experiment timeline
-        window.addEventListener('load', main);
-    </script>
 </html>

--- a/index.html
+++ b/index.html
@@ -28,8 +28,6 @@
 
         <!--maybe one day this plugin will be put in the mainline jsPsych
              repository.-->
-        <script type="module" src="dist/grammar.js"></script>
-        <script type="module" src="dist/parts.js"></script>
 
         <script type="module" src="main.js"></script>
         <style>

--- a/main.js
+++ b/main.js
@@ -209,6 +209,7 @@ function main() {
 
     // Option 1: client side randomization:
     let stimuli = pickRandomList();
+    checkStimuliSyntax(stimuli.table);
     kickOffExperiment(getTimeline(stimuli.table), stimuli.list_name);
 
     // Option 2: server side balancing:

--- a/main.js
+++ b/main.js
@@ -1,3 +1,8 @@
+import {
+    sprMovingWindow,
+    checkStimuliSyntax
+} from './dist/jspsych-spr-moving-window.js'
+
 let jsPsych = initJsPsych({
     exclusions: {
         min_width : MIN_WIDTH,
@@ -281,3 +286,6 @@ function findList(name) {
     }
     return list;
 }
+
+// start the experiment
+window.addEventListener('load', main);

--- a/main.js
+++ b/main.js
@@ -10,6 +10,10 @@ let jsPsych = initJsPsych({
     }
 });
 
+// export jsPsych globally because this is a module now...
+// or export jsPsych and import it from the other files.
+window.jsPsych = jsPsych
+
  // I liked RandomError too :-)
 class SprRandomizationError extends Error {
     constructor(message) {
@@ -43,7 +47,7 @@ let instruction_screen_practice = {
 
 let fixcross = {
     type : sprMovingWindow,
-    stimulus : '+',
+    stimulus : '{{+}}',
     choices : FIX_CHOICES,
     font_family : "Times New Roman",
     font_size : 36,
@@ -140,16 +144,16 @@ let end_experiment = {
 function randomizeStimuli(table) {
     let shuffled = uil.randomization.randomizeStimuli(
         table,
-        max_same_type=MAX_SUCCEEDING_ITEMS_OF_TYPE
+        MAX_SUCCEEDING_ITEMS_OF_TYPE
     );
 
     if (shuffled !== null)
         table = shuffled;
     else {
-            console.error('Unable to shuffle stimuli according constraints.');
-            let msg = "Unable to shuffle the stimuli, perhaps loosen the " +
-                      "constraints, or check the item_types on the stimuli.";
-            throw new SprRandomizationError(msg);
+        console.error('Unable to shuffle stimuli according constraints.');
+        let msg = "Unable to shuffle the stimuli, perhaps loosen the " +
+                  "constraints, or check the item_types on the stimuli.";
+        throw new SprRandomizationError(msg);
     }
 
     return table; // shuffled table if possible original otherwise
@@ -214,6 +218,7 @@ function main() {
 
     // Option 1: client side randomization:
     let stimuli = pickRandomList();
+    checkStimuliSyntax(PRACTICE_ITEMS);
     checkStimuliSyntax(stimuli.table);
     kickOffExperiment(getTimeline(stimuli.table), stimuli.list_name);
 

--- a/main.js
+++ b/main.js
@@ -71,7 +71,6 @@ let present_text = {
     width : MIN_WIDTH,
     height : MIN_HEIGHT,
     post_trial_gap : ISI,
-    grouping_string : GROUPING_STRING,
     data : {
         id : jsPsych.timelineVariable('id'),
         item_type : jsPsych.timelineVariable('item_type'),

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "description": "## A self paced reading with moving window experiment using jsPsych",
   "main": "main.js",
+  "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "./build.bash && node ./plugins/test.js",
     "build": "./build.bash"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "jspsych-spr-mw",
+  "version": "1.0.0",
+  "description": "## A self paced reading with moving window experiment using jsPsych",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "./build.bash"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "moo": "^0.5.2",
+    "nearley": "^2.20.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,8 @@
   "version": "1.0.0",
   "description": "## A self paced reading with moving window experiment using jsPsych",
   "main": "main.js",
-  "type": "module",
   "scripts": {
-    "test": "./build.bash && node ./plugins/test.js",
+    "test": "./build.bash && node ./dist/test.js",
     "build": "./build.bash"
   },
   "keywords": [],
@@ -14,5 +13,8 @@
   "dependencies": {
     "moo": "^0.5.2",
     "nearley": "^2.20.1"
+  },
+  "devDependencies": {
+    "esbuild": "0.24.0"
   }
 }

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -1,3 +1,6 @@
 
 # ignore grammar.js as it is generated from grammar.ne using nearley
 grammar.js
+
+# a test script
+test.js

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -1,0 +1,3 @@
+
+# ignore grammar.js as it is generated from grammar.ne using nearley
+grammar.js

--- a/plugins/grammar.ne
+++ b/plugins/grammar.ne
@@ -11,7 +11,7 @@
         bold_end        : /<[ ]*[/]b[ ]*>/u     ,
         italic_start    : /<[ ]*i[ ]*>/u        ,
         italic_end      : /<[ ]*[/]i[ ]*>/u     ,
-        word            : /\p{L}+|\p{P}+/u      ,
+        word            : /\p{L}+|\p{P}|\p{S}+/u ,
         ws              : /[ \r\t]+/u           ,
         newline         : {match : "\n", lineBreaks: true},
     })
@@ -127,7 +127,7 @@ special_sentence ->  # sentences in bold/italics
 
 bold_sentence -> %bold_start sentence %bold_end {%
                                         // drop italic_start and italic_end, return
-                                        // the sentence with all word marked italic.
+                                        // the sentence with all word marked bold.
                                         function(data) {
                                             let sentence_fragment = data[1];
                                             sentence_fragment.mark_bold();
@@ -167,10 +167,10 @@ WS ->
                                     %}
     | %newline                      {%
                                         function(data, pos) {
-                                            let ws = new parts.WhiteSpace(
+                                            let nl = new parts.WhiteSpace(
                                                 data[0],
                                                 data[0].toString()
                                             );
-                                            return ws;
+                                            return nl;
                                         }
                                     %}

--- a/plugins/grammar.ne
+++ b/plugins/grammar.ne
@@ -1,0 +1,149 @@
+
+@{%
+    import * as parts from "./parts";
+
+    import * as moo from 'moo';
+
+    const lexer = moo.compile({
+        rec_group_start : "{{#"                 ,
+        group_start     : "{{"                  ,
+        group_end       : "}}"                  ,
+        bold_start      : /<[ ]*b[ ]*>/u        ,
+        bold_end        : /<[ ]*[/]b[ ]*>/u     ,
+        italic_start    : /<[ ]*i[ ]*>/u        ,
+        italic_end      : /<[ ]*[/]i[ ]*>/u     ,
+        word            : /\p{L}+/u             ,
+        ws              : /[ \r\t]+/u           ,
+        newline         : {match : "\n", lineBreaks: true},
+    })
+%}
+
+@lexer lexer
+
+# We parse a number of groups to present to the user.
+group_list ->
+      group                 # a single group can be a group_list
+    | group_list group      # a group may be a group followed by more groups
+    | group_list WS group   # allow white space between groups
+    | group_list WS         # allow trailing white space
+
+# A group starts with {{ or {{# and ends with a}} we don't allow empty groups
+# {{}} or {{#}}
+group ->
+	  %group_start sentence %group_end
+	| %rec_group_start sentence %group_end
+
+
+sentence ->
+	  Word                          {%
+                                        function(data) {
+                                            let sentence = new parts.SentenceList(
+                                                data[0].text_position,
+                                            );
+                                            sentence.push(data[0]);
+                                            return sentence;
+                                        }
+                                    %}
+	| WS                            {%
+                                        function(data) {
+                                            let sentence = new parts.SentenceList(
+                                                data[0].text_position,
+                                            );
+                                            sentence.push(data[0]);
+                                            return sentence;
+                                        }
+                                    %}
+    | special_sentence              {% id %}
+
+	| sentence Word                 {%
+                                        function(data) {
+                                            let sentence: parts.SentenceList;
+                                            sentence = data[0];
+                                            sentence.push(data[1]);
+                                            return sentence;
+                                        }
+                                    %}
+    | sentence WS                   {%
+                                        function(data) {
+                                            let sentence: parts.SentenceList;
+                                            sentence = data[0];
+                                            sentence.push(data[1]);
+                                            return sentence;
+                                        }
+                                    %}
+    | sentence special_sentence     {%
+                                        function(data) {
+                                            let sentence: parts.SentenceList;
+                                            let special_sentence: parts.SentenceList;
+
+                                            sentence = data[0];
+                                            special_sentence = data[1];
+
+                                            function append_to_sentence(
+                                                    part: parts.SentencePart)
+                                            {
+                                                sentence.parts.push(part);
+                                            }
+
+                                            special_sentence.parts.forEach(
+                                                append_to_sentence
+                                            )
+                                            return sentence;
+                                        }
+                                    %}
+
+special_sentence ->  # sentences in bold/italics
+      bold_sentence                 {% id %} # id just returns the first element.
+    | italic_sentence               {% id %}
+
+bold_sentence -> %bold_start sentence %bold_end {%
+                                        // drop italic_start and italic_end, return
+                                        // the sentence with all word marked italic.
+                                        function(data) {
+                                            let sentence_fragment: parts.SentenceList
+                                            sentence_fragment = data[1];
+                                            sentence_fragment.mark_bold();
+                                            return data[1]; // strip start and end
+                                        }
+                                    %}
+
+italic_sentence -> %italic_start sentence %italic_end {%
+                                        // drop italic_start and italic_end, return
+                                        // the sentence with all word marked italic.
+                                        function(data) {
+                                            let sentence_fragment: parts.SentenceList
+                                            sentence_fragment = data[1];
+                                            sentence_fragment.mark_italian();
+                                            return data[1]; // strip start and end
+                                        }
+                                    %}
+
+Word -> %word                       {%
+                                        function(data, pos) {
+                                            let word = new parts.Word(
+                                                data[0],
+                                                data[0].toString()
+                                            );
+                                            return word;
+                                        }
+                                    %}
+
+WS ->
+      %ws                           {%
+                                        function(data, pos) {
+                                            let ws = new parts.WhiteSpace(
+                                                data[0],
+                                                data[0].toString()
+                                            );
+                                            return ws;
+                                        }
+                                    %}
+    | %newline                      {%
+                                        function(data, pos) {
+                                            let ws = new parts.WhiteSpace(
+                                                data[0],
+                                                data[0].toString()
+                                            );
+                                            return ws;
+                                        }
+                                    %}

--- a/plugins/grammar.ne
+++ b/plugins/grammar.ne
@@ -1,8 +1,9 @@
 
 @{%
-    import * as parts from "./parts";
 
-    import * as moo from 'moo';
+    const parts = require("./parts.js");
+    const moo = require("moo");
+//    import * as moo from "moo";
 
     const lexer = moo.compile({
         rec_group_start : "{{#"                 ,
@@ -57,30 +58,24 @@ sentence ->
 
 	| sentence Word                 {%
                                         function(data) {
-                                            let sentence: parts.SentenceList;
-                                            sentence = data[0];
+                                            let sentence = data[0];
                                             sentence.push(data[1]);
                                             return sentence;
                                         }
                                     %}
     | sentence WS                   {%
                                         function(data) {
-                                            let sentence: parts.SentenceList;
-                                            sentence = data[0];
+                                            let sentence = data[0];
                                             sentence.push(data[1]);
                                             return sentence;
                                         }
                                     %}
     | sentence special_sentence     {%
                                         function(data) {
-                                            let sentence: parts.SentenceList;
-                                            let special_sentence: parts.SentenceList;
+                                            let sentence = data[0];
+                                            let special_sentence = data[1];
 
-                                            sentence = data[0];
-                                            special_sentence = data[1];
-
-                                            function append_to_sentence(
-                                                    part: parts.SentencePart)
+                                            function append_to_sentence(part)
                                             {
                                                 sentence.parts.push(part);
                                             }
@@ -100,8 +95,7 @@ bold_sentence -> %bold_start sentence %bold_end {%
                                         // drop italic_start and italic_end, return
                                         // the sentence with all word marked italic.
                                         function(data) {
-                                            let sentence_fragment: parts.SentenceList
-                                            sentence_fragment = data[1];
+                                            let sentence_fragment = data[1];
                                             sentence_fragment.mark_bold();
                                             return data[1]; // strip start and end
                                         }
@@ -111,8 +105,7 @@ italic_sentence -> %italic_start sentence %italic_end {%
                                         // drop italic_start and italic_end, return
                                         // the sentence with all word marked italic.
                                         function(data) {
-                                            let sentence_fragment: parts.SentenceList
-                                            sentence_fragment = data[1];
+                                            let sentence_fragment = data[1];
                                             sentence_fragment.mark_italian();
                                             return data[1]; // strip start and end
                                         }

--- a/plugins/grammar.ne
+++ b/plugins/grammar.ne
@@ -20,6 +20,9 @@
 @lexer lexer
 
 # We parse a number of groups to present to the user.
+# We allow white space between the groups. The white space is
+# now made significant. So you don't have to embed the whitespace inside
+# the groups in order to have them "rendered"/appear.
 group_list ->
       group                 # a single group can be a group_list
             {%
@@ -29,23 +32,25 @@ group_list ->
                     return list;
                 }
             %}
-    | group_list group      # a group may be a group followed by more groups
+    | WS                    # white space is part of the group list.
+                            # as this makes writing the stimuli easier.
+            {%
+                function (data) {
+                    let list = new parts.GroupList(data[0].text_position);
+                    list.push(data[0]);
+                }
+            %}
+    | group_list group      # a group list may be followed by more groups
             {%
                 function (data) {
                     data[0].push(data[1])
                     return data[0];
                 }
             %}
-    | group_list WS group   # allow white space between groups
+    | group_list WS         # allow white space between groups
             {%
                 function (data) {
-                    data[0].push(data[2])
-                    return data[0];
-                }
-            %}
-    | group_list WS         # allow trailing white space
-            {%
-                function (data) { // Just ignore the whitespace
+                    data[0].push(data[1])
                     return data[0];
                 }
             %}

--- a/plugins/jspsych-spr-moving-window.js
+++ b/plugins/jspsych-spr-moving-window.js
@@ -1,3 +1,5 @@
+
+
 var sprMovingWindow = (function(jspsych) {
 
     const SPR_MW_PLUGIN_NAME = 'spr-moving-window';

--- a/plugins/jspsych-spr-moving-window.js
+++ b/plugins/jspsych-spr-moving-window.js
@@ -404,8 +404,8 @@ export var sprMovingWindow = (function(jspsych) {
         const BASE_X = determineLineHeight(trial_pars.font_family, trial_pars.font_size);
 
         for (let line = 0; line < lines.length; line++) {
-            liney = BASE_Y + line * delta_y;
-            fragments = lines[line].split(RE_CAP_WHITE_SPACE);
+            let liney = BASE_Y + line * delta_y;
+            let fragments = lines[line].split(RE_CAP_WHITE_SPACE);
             fragments = fragments.filter( word => {return word != "";});
             let runningx = BASE_X;
             for (let fragment = 0; fragment < fragments.length; fragment++) {
@@ -598,7 +598,12 @@ export function checkStimuliSyntax(list)
     list.forEach(trial => {
         const parser = new nearley.Parser(nearley.Grammar.fromCompiled(spr_grammar))
         parser.feed(trial.stimulus)
-        tree = parser.results
-        console.log()
+        let tree = parser.results
+        if (tree.length > 1) {
+            console.log("Oops, grammar is ambiguous.");
+        }
+        else {
+            console.log(JSON.stringify(tree, null, "  "));
+        }
     });
 }

--- a/plugins/jspsych-spr-moving-window.js
+++ b/plugins/jspsych-spr-moving-window.js
@@ -1,6 +1,8 @@
 
+import * as spr_grammar from "./grammar.js";
+import * as nearley from "nearley";
 
-var sprMovingWindow = (function(jspsych) {
+export var sprMovingWindow = (function(jspsych) {
 
     const SPR_MW_PLUGIN_NAME = 'spr-moving-window';
 
@@ -171,9 +173,9 @@ var sprMovingWindow = (function(jspsych) {
         constructor(text, position, ctx, font_family, font_size) {
             if (typeof(text) !== "string")
                 console.error("TextInfo constructor text was not a String");
-            if (!position instanceof Pos)
+            if (!(position instanceof Pos))
                 console.error("TextInfo constructor position was not a Pos");
-            if (!ctx instanceof CanvasRenderingContext2D)
+            if (!(ctx instanceof CanvasRenderingContext2D))
                 console.error("TextInfo constructor cts was not a valid "+
                               "CanvasRenderingContext2D");
             if (typeof(font_family) !== "string")
@@ -583,3 +585,20 @@ var sprMovingWindow = (function(jspsych) {
     return SprMovingWindowPlugin;
 
 })(jsPsychModule);
+
+
+/**
+ * 
+ * @param {Array.<object>} trials is a list of trials
+ * @param {Array.<object>.stimulus} stimulus a stimulus for this trial
+ * 
+ */
+export function checkStimuliSyntax(list)
+{
+    list.forEach(trial => {
+        const parser = new nearley.Parser(nearley.Grammar.fromCompiled(spr_grammar))
+        parser.feed(trial.stimulus)
+        tree = parser.results
+        console.log()
+    });
+}

--- a/plugins/jspsych-spr-moving-window.js
+++ b/plugins/jspsych-spr-moving-window.js
@@ -260,7 +260,6 @@ export var sprMovingWindow = (function(jspsych) {
         let stimulus = trial_pars.stimulus;
         let parsed_stimulus = parseSpr(stimulus);
         groups = createGroups(parsed_stimulus);
-        console.log(groups);
         gatherWordInfo(parsed_stimulus, trial_pars);
     }
 
@@ -278,7 +277,9 @@ export var sprMovingWindow = (function(jspsych) {
         };
 
         groups.forEach(
-            function (group) {
+            function (group) { // A group might be WhiteSpace here
+                if (group.get_type() == "WhiteSpace")
+                    return;
                 let group_indices = [];
                 let record = group.record;
                 let sentence_parts = group.sentence_parts.parts;
@@ -363,19 +364,25 @@ export var sprMovingWindow = (function(jspsych) {
         }
 
         let groups = parsed_stimulus.groups;
-        groups.forEach(
+        groups.forEach( // A group can be a whitespace
             group => {
-                let parts = group.sentence_parts.parts;
-                parts.forEach(
-                    part => {
-                        if (part.get_type() == "WhiteSpace") {
-                            advanceWhiteSpace(context, part);
+                let type = group.get_type();
+                if (type == "WhiteSpace") {
+                    advanceWhiteSpace(context, group);
+                }
+                else if (type == "Group") {
+                    let parts = group.sentence_parts.parts;
+                    parts.forEach(
+                        part => {
+                            if (part.get_type() == "WhiteSpace") {
+                                advanceWhiteSpace(context, part);
+                            }
+                            else if (part.get_type() == "Word") {
+                                advanceWord(context, part);
+                            }
                         }
-                        else if (part.get_type() == "Word") {
-                            advanceWord(context, part);
-                        }
-                    }
-                );
+                    );
+                }
             }
         );
 

--- a/plugins/jspsych-spr-moving-window.js
+++ b/plugins/jspsych-spr-moving-window.js
@@ -70,18 +70,6 @@ export var sprMovingWindow = (function(jspsych) {
                 default :       600,
                 description :   "The height of the canvas in which the spr moving window is presented"
             },
-            grouping_string : {
-                type :          jspsych.ParameterType.STRING,
-                pretty_name :   "grouping string",
-                default :       null,
-                description :   "The string used to split the string in to parts. The parts are "  +
-                    "presented together. This allows to present multiple words as "    +
-                    "group if the argument isn't specified every single word is "      +
-                    "treated as group. You should make sure that the used argument "   +
-                    "doesn't appear at other locations than at boundaries of groups, " +
-                    "because the grouping character is removed from the string. a "    +
-                    "'/' can be used quite handy for example."
-            },
             line_height_multiplier : {
                 type :          jspsych.ParameterType.FLOAT,
                 pretty_name :   "line_height_multiplier",

--- a/plugins/parts.js
+++ b/plugins/parts.js
@@ -109,7 +109,7 @@ export class SentenceList extends GrammarPart {
         );
     }
     
-    mark_italian() {
+    mark_italic() {
         this.parts.forEach(
             function(value) {
                 if (value.grammar_type_name == "Word") {
@@ -143,7 +143,7 @@ export class SentencePart extends GrammarPart {
 export class Word extends SentencePart {
 
     bold = false;
-    italian = false;
+    italic = false;
 
     /**
      * 

--- a/plugins/parts.js
+++ b/plugins/parts.js
@@ -1,0 +1,212 @@
+
+/**
+ * Class representing the position of a portion of the grammar
+ */
+export class PositionInfo {
+
+    /**
+     * 
+     * @param {object} tokenised Where the token is found by the lexer
+     * @param {number} tokenised.col
+     * @param {number} tokenised.line
+     * @param {number} tokenised.lineBreaks
+     * @param {number} tokenised.offset
+     */
+    constructor(tokenised) {
+        try {
+            if (typeof tokenised.col !== "number") {
+                throw new TypeError("tokenised.column should be a number");
+            }
+            if (typeof tokenised.line !== "number") {
+                throw new TypeError("tokenised.line should be a number");
+            }
+            if (typeof tokenised.lineBreaks !== "number") {
+                throw new TypeError("tokenised.lineBreaks should be a number");
+            }
+            if (typeof tokenised.offset !== "number") {
+                throw new TypeError("tokenised.offset should be a number");
+            }
+        } catch (e) {
+            let breakpoint = e;
+        }
+
+        this.col = tokenised.col;
+        this.line = tokenised.line;
+        this.lineBreaks = tokenised.lineBreaks;
+        this.offset = tokenised.offset;
+    }
+}
+
+/**
+ * A grammar part is one symbol inside of the parsed text.
+ * It can be a terminal or non terminal part of the grammar.
+ */
+export class GrammarPart {
+
+    /**
+     * 
+     * @param {string} type_name What constinuent of the grammar this object is
+     * @param {PositionInfo} text_position Where is the constinuent in the parsed string
+     */
+    constructor(type_name, text_position) {
+        if (typeof typename !== "string") {
+            throw new TypeError("type_name should be a string");
+        }
+        if (typeof text_position !== "object") {
+            throw new TypeError("type_name should be an object");
+        }
+        this.grammar_type_name = type_name;
+        this.text_position = new PositionInfo(text_position);
+    }
+
+    /**
+     * 
+     * @returns {string} What kind of symbol of the grammar this is
+     */
+    get_type () {
+        return this.grammar_type_name;
+    }
+
+    /**
+     * 
+     * @returns {PositionInfo} Information about where this grammar symol
+     *                         is inside the text.
+     */
+    get_position() {
+        return this.text_position;
+    }
+}
+
+export class SentenceList extends GrammarPart {
+
+    /**
+     * 
+     * @param {PositionInfo} position 
+     */
+    constructor(position) {
+        super("SentenceList", position)
+        this.parts = [];
+    }
+
+    /**
+     * 
+     * @param {SentencePart} part 
+     */
+    push(part) {
+        if (part instanceof SentencePart)
+            this.parts.push(part);
+        else
+            throw new TypeError("Part was expected to be a SentencePart")
+    }
+
+    mark_bold() {
+        this.parts.forEach(
+            function(value) {
+                if (value.grammar_type_name == "Word") {
+                    wordval.mark_bold();
+                }
+            }
+        );
+    }
+    
+    mark_italian() {
+        this.parts.forEach(
+            function(value) {
+                if (value.grammar_type_name == "Word") {
+                    value.mark_italian();
+                }
+            }
+        );
+    }
+}
+
+export class SentencePart extends GrammarPart {
+
+    /**
+     * 
+     * @param {string} type 
+     * @param {PositionInfo} position 
+     * @param {string} content 
+     */
+    constructor(type, position, content) {
+        super(type, position);
+        if (typeof(content) !== "string")
+            throw TypeError("text is not a string.");
+        this.content = content;
+    }
+
+    get_content() {
+        return this.content;
+    }
+}
+
+export class Word extends SentencePart {
+
+    bold = false;
+    italian = false;
+
+    /**
+     * 
+     * @param {PositionInfo} position 
+     * @param {string} text 
+     */
+
+    constructor (position, text) {
+        super("Word", position, text);
+        this.bold = false;
+        this.italic = false
+    }
+
+    mark_bold() {this.bold = true;}
+    mark_italic() {this.italic = true;}
+}
+
+export class WhiteSpace extends SentencePart {
+
+    /**
+     * 
+     * @param {PositionInfo} position 
+     * @param {string} text 
+     */
+    constructor (position, text) {
+        super("WhiteSpace", position, text);
+    }
+};
+
+
+export class Group extends GrammarPart {
+
+    /**
+     * @param {PositionInfo} position 
+     * @param {boolean} record 
+     * @param {SentenceList} sentence_parts 
+     */
+    constructor(position, record, sentence_parts) {
+        super("Group", position);
+        if (typeof record !== "boolean")
+            throw new TypeError("Record was expected to be boolean")
+        this.record = record
+        this.sentence_parts = sentence_parts;
+    }
+}
+
+export class GroupList extends GrammarPart {
+    /**
+     * 
+     * @param {PositionInfo} position 
+     */
+    constructor (position) {
+        super("GroupList", position);
+        this.groups = []
+    }
+
+    /**
+     * Push a single group to the list of groups
+     * 
+     * @param {Group} group 
+     */
+    push(group) {
+        this.groups.push(group)
+    }
+};
+

--- a/plugins/parts.js
+++ b/plugins/parts.js
@@ -49,7 +49,7 @@ export class GrammarPart {
      * @param {PositionInfo} text_position Where is the constinuent in the parsed string
      */
     constructor(type_name, text_position) {
-        if (typeof typename !== "string") {
+        if (typeof type_name !== "string") {
             throw new TypeError("type_name should be a string");
         }
         if (typeof text_position !== "object") {
@@ -103,7 +103,7 @@ export class SentenceList extends GrammarPart {
         this.parts.forEach(
             function(value) {
                 if (value.grammar_type_name == "Word") {
-                    wordval.mark_bold();
+                    value.mark_bold();
                 }
             }
         );
@@ -113,7 +113,7 @@ export class SentenceList extends GrammarPart {
         this.parts.forEach(
             function(value) {
                 if (value.grammar_type_name == "Word") {
-                    value.mark_italian();
+                    value.mark_italic();
                 }
             }
         );

--- a/plugins/parts.js
+++ b/plugins/parts.js
@@ -44,7 +44,7 @@ export class PositionInfo {
 export class GrammarPart {
 
     /**
-     * 
+     * @constructor
      * @param {string} type_name What constinuent of the grammar this object is
      * @param {PositionInfo} text_position Where is the constinuent in the parsed string
      */
@@ -80,7 +80,7 @@ export class GrammarPart {
 export class SentenceList extends GrammarPart {
 
     /**
-     * 
+     * @constructor
      * @param {PositionInfo} position 
      */
     constructor(position) {
@@ -102,9 +102,7 @@ export class SentenceList extends GrammarPart {
     mark_bold() {
         this.parts.forEach(
             function(value) {
-                if (value.grammar_type_name == "Word") {
-                    value.mark_bold();
-                }
+                value.mark_bold();
             }
         );
     }
@@ -112,15 +110,16 @@ export class SentenceList extends GrammarPart {
     mark_italic() {
         this.parts.forEach(
             function(value) {
-                if (value.grammar_type_name == "Word") {
-                    value.mark_italic();
-                }
+                value.mark_italic();
             }
         );
     }
 }
 
 export class SentencePart extends GrammarPart {
+
+    bold = false;
+    italic = false;
 
     /**
      * 
@@ -133,43 +132,54 @@ export class SentencePart extends GrammarPart {
         if (typeof(content) !== "string")
             throw TypeError("text is not a string.");
         this.content = content;
+        this.bold = false;
+        this.italic = false
     }
 
     get_content() {
         return this.content;
     }
+    
+    mark_bold() {this.bold = true;}
+    mark_italic() {this.italic = true;}
 }
 
+
+// Words are different from WhiteSpace in terms of
+// how they are used by the self paced reading.
+// That explains the code duplication.
 export class Word extends SentencePart {
 
-    bold = false;
-    italic = false;
-
     /**
-     * 
      * @param {PositionInfo} position 
      * @param {string} text 
      */
-
     constructor (position, text) {
         super("Word", position, text);
-        this.bold = false;
-        this.italic = false
     }
 
-    mark_bold() {this.bold = true;}
-    mark_italic() {this.italic = true;}
 }
 
 export class WhiteSpace extends SentencePart {
 
     /**
-     * 
+     * @constructor
      * @param {PositionInfo} position 
      * @param {string} text 
      */
     constructor (position, text) {
         super("WhiteSpace", position, text);
+    }
+};
+
+export class NewLine extends SentencePart {
+    /**
+     * @constructor
+     * @param {PositionInfo} position
+     * @param {string} text
+     */
+    constructor (position, text) {
+        super("NewLine", position, text);
     }
 };
 

--- a/stimuli.js
+++ b/stimuli.js
@@ -38,7 +38,7 @@ const PRACTICE_ITEMS = [
         //inside the bold tag. Open a new tag when the overlap partially.
         //<b><i>but</i></b><i>this is</i> valid.
         stimulus :
-            "{{The <b>teacher took <i>the car</i></b><i> instead</i> of }}{{the }}{{express }}"    + // string1
+            "{{The <b>teacher took <i>the car</i></b><i> instead</i> of}} {{the }}{{express }}"    + // string1
             "{{train\n}}{{due to the previously announced public\n"                                 + // string2
             "transport strike.}}", // use a comma here on the final line of your stimulus.             // final string
         question : "",                                            // An empty string means no question for this trial.

--- a/stimuli.js
+++ b/stimuli.js
@@ -38,8 +38,8 @@ const PRACTICE_ITEMS = [
         //inside the bold tag. Open a new tag when the overlap partially.
         //<b><i>but</i></b><i>this is</i> valid.
         stimulus :
-            "{{The <b>teacher took <i>the car</i></b><i> instead</i> of}} {{the }}{{express }}"    + // string1
-            "{{train\n}}{{due to the previously announced public\n"                                 + // string2
+            "{{The <b>teacher took <i>the car</i></b><i> instead</i> of}} {{the}} {{express}} {{train}}\n"    + // string1
+            "{{due to the previously announced public\n"                                                      + // string2
             "transport strike.}}", // use a comma here on the final line of your stimulus.             // final string
         question : "",                                            // An empty string means no question for this trial.
         qanswer : undefined                                       // We can't define a answer if there ain't no question.
@@ -48,8 +48,8 @@ const PRACTICE_ITEMS = [
         id : 2,
         item_type : PRAC,
         stimulus :
-            "{{The researcher presented his most recent work\n}}"   +
-            "{{to }}{{the }}{{commission }}{{and obtained very positive\n"    +
+            "{{The researcher presented his most recent work}}\n"   +
+            "{{to}} {{the}} {{commission}} {{and obtained very positive\n"    + // Line endings inside a group are fine
             "comments regarding the experimental design.}}"     ,
         question : "The researcher presented old work.",
         qanswer : FALSE_BUTTON_TEXT                               // Use TRUE_BUTTON_TEXT if the answer is true,
@@ -59,16 +59,18 @@ const PRACTICE_ITEMS = [
 
 /*
  * In this list there is a stimulus, if a group of words starts with a
- * '{{#' it's reaction time will be recorded.
+ * '{{#' it's reaction time will be recorded. In the list for group 1
+ * the space is moved outside of a group. I think this make it easier to
+ * read the stimulus.
  */
 const LIST_GROUP1 = [
     {
         id : 1,
         item_type : PASSIVE,
         stimulus :
-            "{{The guitarist was rejected by }}{{#the }}{{#attractive }}{{#and\n}}"                 +
-            "{{#talented }}{{#singer }}{{#in }}{{#the }}{{#concert }}{{#hall }}{{#next }}{{#to\n}}" +
-            "{{#the }}{{#Irish }}{{#pub.\n}}",
+            "{{The guitarist was rejected by}} {{#the}} {{#attractive}} {{#and}}\n"                 +
+            "{{#talented}} {{#singer}} {{#in}} {{#the}} {{#concert}} {{#hall}} {{#next}} {{#to}}\n" +
+            "{{#the}} {{#Irish}} {{#pub.}}\n",
         question : "The singer was attractive.",
         qanswer : TRUE_BUTTON_TEXT
     },
@@ -76,9 +78,9 @@ const LIST_GROUP1 = [
         id : 2,
         item_type : ACTIVE,
         stimulus :
-            "{{The sculptor mugged }}{{#the }}{{#strange }}{{#and\n}}"                      +
-            "{{#temperamental }}{{#photographer }}{{#in }}{{#the }}{{#art }}{{#gallery\n}}" +
-            "{{#next }}{{#to }}{{#the }}{{#book }}{{#shop.\n}}"                             ,
+            "{{The sculptor mugged}} {{#the}} {{#strange}} {{#and}}\n"                      +
+            "{{#temperamental}} {{#photographer}} {{#in}} {{#the}} {{#art}} {{#gallery}}\n" +
+            "{{#next}} {{#to}} {{#the}} {{#book}} {{#shop.}}"                               ,
         question : "",
         qanswer : undefined
     },
@@ -86,9 +88,9 @@ const LIST_GROUP1 = [
         id : 3,
         item_type : FILLER,
         stimulus :
-            "{{The beautiful princess married her young and\n}}"                +
-            "{{handsome }}{{chauffeur }}{{and }}{{shocked }}{{the royal\n"      +
-            "family and the press.\n}}",
+            "{{The beautiful princess married her young and}}\n"                +
+            "{{handsome}} {{chauffeur}} {{and}} {{shocked}} {{the royal\n"      +
+            "family and the press.}}",
         question : "The chauffeur was an old man.",
         qanswer : FALSE_BUTTON_TEXT
     },
@@ -96,17 +98,19 @@ const LIST_GROUP1 = [
         id : 4,
         item_type : FILLER,
         stimulus :
-            "{{The little girl did not play with her brother\n}}"                               +
-            "{{in }}{{the }}{{colourful }}{{playground }}{{next }}{{to }}{{their }}{{weedy\n}}" +
-            "{{garden.\n}}",
+            "{{The little girl did not play with her brother}}\n"                               +
+            "{{in}} {{the}} {{colourful}} {{playground}} {{next}} {{to}} {{their}} {{weedy}}\n" +
+            "{{garden.}}",
         question : "",
         qanswer : undefined
     }
 ];
 
 /*
- * In this list there is a stimulus, if a word starts with a '#' its
- * reaction time will be recorded. So don't put any '#" elsewhere...
+ * In this list puts all the white space inside of a group, this is also possbile
+ * but I find it less readable. You are allowed to mix it, where necessary. If
+ * you want a group of words that spans multiple lines, it's fine to put a \n
+ * inside the group.
  */
 const LIST_GROUP2 = [
     {

--- a/stimuli.js
+++ b/stimuli.js
@@ -23,16 +23,24 @@ const PRACTICE_ITEMS = [
     {
         id : 1,
         item_type : PRAC,
-
-        stimulus :                                                // Single "/" delimit boundaries between words presented
-                                                                  // together. Boundaries must be activated by setting "/" as
-                                                                  // GROUPING_STRING in globals.js. The default is null
-                                                                  // which means every word is a group of in its own.
-                                                                  // If the grouping string isn't set or null,
-                                                                  // the "/" will be displayed instead of used for grouping.
-            "The teacher took the car instead of the express"   + // The '+' adds strings together or concatenates them.
-            "train \ndue to the previously announced public\n"  + // A "\n" makes the string jump to the next line.
-            "transport strike.\n",                                // use a comma here.
+        //Every word, space "enter" between a pair of {{ and }} is presented
+        //together as one group of words. If a group starts with a {{#, the reaction
+        //will be recorded. Don't put any characters outside of the {{}}} characters
+        //as the grammar for shaping the self paced reading doesn't like that.
+        //
+        //You can go to the next line in this file by adding (+) to strings
+        //together.
+        //
+        //You are allowed to present words in html style bold and italic tags
+        //You can use bold and italic together, but an entire
+        //<b>this is <i>correct</i></b>,
+        //<b><i>but<b/> this isn't</i> as the entire italic phrase must be captured
+        //inside the bold tag. Open a new tag when the overlap partially.
+        //<b><i>but</i></b><i>this is</i> valid.
+        stimulus :
+            "{{The <b>teacher took <i>the car</i></b><i> instead</i> of }}{{the }}{{express }}"    + // string1
+            "{{train\n}}{{due to the previously announced public\n"                                 + // string2
+            "transport strike.}}", // use a comma here on the final line of your stimulus.             // final string
         question : "",                                            // An empty string means no question for this trial.
         qanswer : undefined                                       // We can't define a answer if there ain't no question.
     },
@@ -40,9 +48,9 @@ const PRACTICE_ITEMS = [
         id : 2,
         item_type : PRAC,
         stimulus :
-            "The researcher presented his most recent work\n"   +
-            "to the commission and obtained very positive\n"    +
-            "comments regarding the experimental design.\n"     ,
+            "{{The researcher presented his most recent work\n}}"   +
+            "{{to }}{{the }}{{commission }}{{and obtained very positive\n"    +
+            "comments regarding the experimental design.}}"     ,
         question : "The researcher presented old work.",
         qanswer : FALSE_BUTTON_TEXT                               // Use TRUE_BUTTON_TEXT if the answer is true,
                                                                   // FALSE_BUTTON_TEXT otherwise
@@ -50,17 +58,17 @@ const PRACTICE_ITEMS = [
 ];
 
 /*
- * In this list there is a stimulus, if a word or group of words starts with a
- * '#' it's reaction time will be recorded. So don't put any '#" elsewhere...
+ * In this list there is a stimulus, if a group of words starts with a
+ * '{{#' it's reaction time will be recorded.
  */
 const LIST_GROUP1 = [
     {
         id : 1,
         item_type : PASSIVE,
         stimulus :
-            "The guitarist was rejected by #the #attractive #and\n"     +
-            "#talented #singer #in #the #concert #hall #next #to\n"     +
-            "#the #Irish #pub.\n"                                       ,
+            "{{The guitarist was rejected by }}{{#the }}{{#attractive }}{{#and\n}}"                 +
+            "{{#talented }}{{#singer }}{{#in }}{{#the }}{{#concert }}{{#hall }}{{#next }}{{#to\n}}" +
+            "{{#the }}{{#Irish }}{{#pub.\n}}",
         question : "The singer was attractive.",
         qanswer : TRUE_BUTTON_TEXT
     },
@@ -68,9 +76,9 @@ const LIST_GROUP1 = [
         id : 2,
         item_type : ACTIVE,
         stimulus :
-            "The sculptor mugged #the #strange #and\n"                  +
-            "#temperamental #photographer #in #the #art #gallery\n"     +
-            "#next #to #the #book #shop.\n"                             ,
+            "{{The sculptor mugged }}{{#the }}{{#strange }}{{#and\n}}"                      +
+            "{{#temperamental }}{{#photographer }}{{#in }}{{#the }}{{#art }}{{#gallery\n}}" +
+            "{{#next }}{{#to }}{{#the }}{{#book }}{{#shop.\n}}"                             ,
         question : "",
         qanswer : undefined
     },
@@ -78,9 +86,9 @@ const LIST_GROUP1 = [
         id : 3,
         item_type : FILLER,
         stimulus :
-            "The beautiful princess married her young and\n"            +
-            "handsome chauffeur and shocked the royal\n"                +
-            "family and the press.\n"                                   ,
+            "{{The beautiful princess married her young and\n}}"                +
+            "{{handsome }}{{chauffeur }}{{and }}{{shocked }}{{the royal\n"      +
+            "family and the press.\n}}",
         question : "The chauffeur was an old man.",
         qanswer : FALSE_BUTTON_TEXT
     },
@@ -88,9 +96,9 @@ const LIST_GROUP1 = [
         id : 4,
         item_type : FILLER,
         stimulus :
-            "The little girl did not play with her brother\n"           +
-            "in the colourful playground next to their weedy\n"         +
-            "garden.\n"                                                 ,
+            "{{The little girl did not play with her brother\n}}"                               +
+            "{{in }}{{the }}{{colourful }}{{playground }}{{next }}{{to }}{{their }}{{weedy\n}}" +
+            "{{garden.\n}}",
         question : "",
         qanswer : undefined
     }
@@ -105,9 +113,9 @@ const LIST_GROUP2 = [
         id : 1,
         item_type : ACTIVE,
         stimulus :
-            "The guitarist rejected #the #attractive #and\n"            +
-            "#talented #singer #in #the #concert #hall #next #to\n"     +
-            "#the #Irish #pub.\n"                                       ,
+            "{{The guitarist rejected }}{{#the }}{{#attractive }}{{#and\n}}"                        +
+            "{{#talented }}{{#singer }}{{#in }}{{#the }}{{#concert }}{{#hall }}{{#next }}{{#to\n}}" +
+            "{{#the }}{{#Irish }}{{#pub.\n}}",
         question : "The singer was attractive.",
         qanswer : TRUE_BUTTON_TEXT
     },
@@ -115,9 +123,9 @@ const LIST_GROUP2 = [
         id : 2,
         item_type : PASSIVE,
         stimulus :
-            "The sculptor was mugged by #the #strange #and\n"           +
-            "#temperamental #photographer #in #the #art #gallery\n"     +
-            "#next #to #the #book #shop.\n"                             ,
+            "{{The sculptor was mugged by }}{{#the }}{{#strange }}{{#and\n}}"               +
+            "{{#temperamental }}{{#photographer }}{{#in }}{{#the }}{{#art }}{{#gallery\n}}" +
+            "{{#next }}{{#to }}{{#the }}{{#book }}{{#shop.\n}}",
         question : "",
         qanswer : undefined
     },
@@ -125,9 +133,9 @@ const LIST_GROUP2 = [
         id : 3,
         item_type : FILLER,
         stimulus :
-            "The beautiful princess married her young and\n"            +
-            "handsome chauffeur and shocked the royal\n"                +
-            "family and the press.\n"                                   ,
+            "{{The beautiful princess married her young and\n}}"                    +
+            "{{handsome }}{{chauffeur }}{{and }}{{shocked }}{{the }}{{royal\n}}"    +
+            "{{family and the press.\n}}",
         question : "The chauffeur was an old man.",
         qanswer : FALSE_BUTTON_TEXT
     },
@@ -135,9 +143,9 @@ const LIST_GROUP2 = [
         id : 4,
         item_type : FILLER,
         stimulus :
-            "The little girl did not play with her brother\n"           +
-            "in the colourful playground next to their weedy\n"         +
-            "garden.\n"                                                 ,
+            "{{The little girl did not play with her brother\n}}"           +
+            "{{in }}{{the }}{{colourful }}{{playground }}{{next }}{{to their weedy\n"         +
+            "garden.\n}}"                                                 ,
         question : "",
         qanswer : undefined
     }

--- a/stimuli.js
+++ b/stimuli.js
@@ -158,4 +158,18 @@ const TEST_ITEMS = [
     // {list_name: LISTS[1], table: LIST_GROUP3}
 ];
 
-
+/**
+ * 
+ * @param {Array.<object>} trials is a list of trials
+ * @param {Array.<object>.stimulus} stimulus a stimulus for this trial
+ * 
+ */
+function checkStimuliSyntax(list )
+{
+    list.forEach(trial => {
+        const parser = new nearley.Parser(nearley.Grammar.fromCompiled(spr_grammar))
+        parser.feed(trial.stimulus)
+        tree = parser.results
+        console.log()
+    });
+}

--- a/stimuli.js
+++ b/stimuli.js
@@ -158,18 +158,3 @@ const TEST_ITEMS = [
     // {list_name: LISTS[1], table: LIST_GROUP3}
 ];
 
-/**
- * 
- * @param {Array.<object>} trials is a list of trials
- * @param {Array.<object>.stimulus} stimulus a stimulus for this trial
- * 
- */
-function checkStimuliSyntax(list )
-{
-    list.forEach(trial => {
-        const parser = new nearley.Parser(nearley.Grammar.fromCompiled(spr_grammar))
-        parser.feed(trial.stimulus)
-        tree = parser.results
-        console.log()
-    });
-}


### PR DESCRIPTION
This is a feature reworks the way how stimuli are written for the jspsych-spr-reading. Using the javascript nearley parser and moo lexer frameworks it is possible to create a stimulus where you can be more confident how the stimulus will finaly appear on screen. The former stimulus was removing and replacing characters from the input along a number of dimension which made it hard to see what it was doing.
Now there a grammar that dictates how stimuli should be written see plugins/grammar.ne which is converted to plugins/grammar.js. This is all packaged using esbuild to the dist directory. you can call ./build.sh to recreate grammar.js and populate dist. with a packaged version of the plugin.

It is now easier to create a number of bold/italic words in a row as you can put multiple words within <b></b>  tags, whereas before you had to tag each individual word. The grammar is much stricter than a html parser, as groups need to be closed e.g see the readme for more details